### PR TITLE
Updated to .NET 8

### DIFF
--- a/Ellucian.Ethos.Integration.Test/Ellucian.Ethos.Integration.Test.csproj
+++ b/Ellucian.Ethos.Integration.Test/Ellucian.Ethos.Integration.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Ellucian.Ethos.Integration/Ellucian.Ethos.Integration.csproj
+++ b/Ellucian.Ethos.Integration/Ellucian.Ethos.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Ellucian.Ethos.Integration</PackageId>
     <Version>1.0.0</Version>
     <Authors>Ellucian Ethos Integration Team</Authors>
@@ -34,7 +34,7 @@ The Ethos Integration SDK makes the application development process less expensi
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\net6.0\Ellucian.Ethos.Integration.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net8.0\Ellucian.Ethos.Integration.xml</DocumentationFile>
     <OutputPath>bin\Debug</OutputPath>
   </PropertyGroup>
 
@@ -58,8 +58,8 @@ The Ethos Integration SDK makes the application development process less expensi
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The library is still usable as-is, targeting .NET 6.  However, update to .NET 8 to maintain Microsoft support.